### PR TITLE
Add suggested messages to the conversation (#34)

### DIFF
--- a/lib/components/model/model.dart
+++ b/lib/components/model/model.dart
@@ -72,6 +72,16 @@ extension ConversationUtil on g.Conversation {
     var result = m2.datetime.compareTo(m1.datetime);
     return result != 0 ? result : c2.hashCode.compareTo(c1.hashCode);
   }
+
+  /// Remove the suggested messages for this Conversation.
+  /// Callers should catch and handle IOException.
+  Future<void> removeSuggestedMessages(g.DocPubSubUpdate pubSubClient) async {
+    if (suggestedMessages.isEmpty) return;
+    suggestedMessages.clear();
+    return pubSubClient.publishAddOpinion('nook_conversation/delete_suggested_messages', {
+      "conversation_id": docId,
+    });
+  }
 }
 
 extension MessageUtil on g.Message {
@@ -94,11 +104,12 @@ extension MessageUtil on g.Message {
   /// Remove [tagId] from tagIds in this Message.
   /// Callers should catch and handle IOException.
   Future<void> removeTagId(g.DocPubSubUpdate pubSubClient, g.Conversation conversation, String tagId, {bool wasSuggested = false}) async {
-    if (!tagIds.contains(tagId)) return;
+    if (!tagIds.contains(tagId) && !suggestedTagIds.contains(tagId)) return;
     if (this.id == null) {
       throw AssertionError('Cannot remove a tag from a pending message - please try again in a few seconds');
     }
     tagIds.remove(tagId);
+    suggestedTagIds.remove(tagId);
     return pubSubClient.publishAddOpinion('nook_messages/remove_tags', {
       "conversation_id": conversation.docId,
       "message_id": this.id,

--- a/lib/components/model/model.g.dart
+++ b/lib/components/model/model.g.dart
@@ -64,6 +64,7 @@ class Conversation {
   Set<String> suggestedTagIds;
   Set<String> lastInboundTurnTagIds;
   List<Message> messages;
+  List<SuggestedMessage> suggestedMessages;
   String notes;
   bool unread;
 
@@ -78,6 +79,7 @@ class Conversation {
       ..suggestedTagIds = Set_fromData<String>(data['suggested_tag_ids_set'], String_fromData) ?? {}
       ..lastInboundTurnTagIds = Set_fromData<String>(data['lastInboundTurnTags'], String_fromData) ?? {}
       ..messages = List_fromData<Message>(data['messages'], Message.fromData)
+      ..suggestedMessages = List_fromData<SuggestedMessage>(data['suggested_messages'], SuggestedMessage.fromData) ?? []
       ..notes = String_fromData(data['notes'])
       ..unread = bool_fromData(data['unread']) ?? true;
   }
@@ -107,6 +109,7 @@ class Conversation {
       if (suggestedTagIds != null) 'suggested_tag_ids_set': suggestedTagIds.toList(),
       if (lastInboundTurnTagIds != null) 'lastInboundTurnTags': lastInboundTurnTagIds.toList(),
       if (messages != null) 'messages': messages.map((elem) => elem?.toData()).toList(),
+      if (suggestedMessages != null) 'suggested_messages': suggestedMessages.map((elem) => elem?.toData()).toList(),
       if (notes != null) 'notes': notes,
       if (unread != null) 'unread': unread,
     };
@@ -353,6 +356,42 @@ class MessageStatus {
 
   @override
   String toString() => toData();
+}
+
+class SuggestedMessage {
+  String text;
+  String translation;
+
+  static SuggestedMessage fromData(data, [SuggestedMessage modelObj]) {
+    if (data == null) return null;
+    return (modelObj ?? SuggestedMessage())
+      ..text = String_fromData(data['text'])
+      ..translation = String_fromData(data['translation']);
+  }
+
+  static SuggestedMessage required(Map data, String fieldName, String className) {
+    var value = fromData(data[fieldName]);
+    if (value == null && !data.containsKey(fieldName))
+      throw ValueException("$className.$fieldName is missing");
+    return value;
+  }
+
+  static SuggestedMessage notNull(Map data, String fieldName, String className) {
+    var value = required(data, fieldName, className);
+    if (value == null)
+      throw ValueException("$className.$fieldName must not be null");
+    return value;
+  }
+
+  Map<String, dynamic> toData() {
+    return {
+      if (text != null) 'text': text,
+      if (translation != null) 'translation': translation,
+    };
+  }
+
+  @override
+  String toString() => 'SuggestedMessage: ${toData().toString()}';
 }
 
 class SuggestedReply {

--- a/lib/components/model/model.yaml
+++ b/lib/components/model/model.yaml
@@ -10,6 +10,7 @@ Conversation:
   suggested_tag_ids_set: 'set string suggestedTagIds, default {}'
   lastInboundTurnTags: 'set string lastInboundTurnTagIds, default {}'
   messages: 'array Message'
+  suggested_messages: 'array SuggestedMessage suggestedMessages, default []'
   notes: 'publishable string'
   unread: 'publishable bool, default true'
 
@@ -39,6 +40,11 @@ MessageStatus:
     - confirmed
     - failed
     - unknown
+
+SuggestedMessage:
+  firebaseDocId: 'none'
+  text: 'string'
+  translation: 'string'
 
 SuggestedReply:
   firebaseCollectionName: 'suggestedReplies'


### PR DESCRIPTION
TBR - accidentally merged #34 into #33  instead of changing the base to `main`

* Add suggested messages to the conversation

* Fix remove suggested tag logic

* Fix bug where the messages weren't being removed

* Rename suggested messages to snake_case in firebase

Co-authored-by: Luke Church <luke@church.name>